### PR TITLE
Fix worker crash and remove day-night effect

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ let mapW = 0, mapH = 0;
 let tiles, agents = { x: [], y: [], age: [], hunger: [], home: [], skillFood: [], skillWood: [] }, houses = [];
 let stats = { pop: 0, food: 0, wood: 0 }, fps = 0;
 let lastTime = performance.now();
-let dayTime  = 0;
+// убираем смену дня и ночи
 
 // учёт DPR для чётких пикселей
 const dpr = Math.min(window.devicePixelRatio || 1, 2);
@@ -74,7 +74,6 @@ function render() {
   const now = performance.now();
   const dt  = (now - lastTime) / 1000;
   lastTime = now;
-  dayTime += dt * 0.1;
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.save();
@@ -117,10 +116,6 @@ function render() {
   }
 
   ctx.restore();
-
-  const light = 0.6 + 0.4 * Math.sin(dayTime);
-  ctx.fillStyle = `rgba(0,0,0,${1 - light})`;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // обновляем HUD
   hud.pop.textContent  = `Pop:  ${stats.pop}`;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -41,6 +41,7 @@ const homeId = new Int16Array(MAX_AGENTS);
 const skillFood = new Uint16Array(MAX_AGENTS);
 const skillWood = new Uint16Array(MAX_AGENTS);
 const workTimer = new Float32Array(MAX_AGENTS);
+const jobType  = new Uint8Array(MAX_AGENTS);
 const role   = new Uint8Array(MAX_AGENTS);
 let agentCount = 0;
 


### PR DESCRIPTION
## Summary
- add missing `jobType` array to simulation worker
- clean up day/night overlay code in the renderer

## Testing
- `node --check main.js`
- `node --check sim.worker.js`

------
https://chatgpt.com/codex/tasks/task_e_6859d3e5690c8332829795ab0b26ec8f