### PR TITLE
Improve villager logic and add game speed control

### DIFF
--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -55,6 +55,17 @@ export function update (id, dt, world) {
     }
   }
 
+  // дети до 16 лет не покидают дом
+  if (age[id] < 16 && homeId[id] >= 0) {
+    const hx = houseX[homeId[id]], hy = houseY[homeId[id]];
+    if (posX[id] === hx && posY[id] === hy) {
+      energy[id] = Math.min(100, energy[id] + dt * 10);
+    } else {
+      stepToward(id, hx, hy, world);
+    }
+    return;
+  }
+
   // отдых в доме при низкой энергии
   if (energy[id] < 20 && houseCount > 0) {
     let best = Infinity, tx = posX[id], ty = posY[id];
@@ -115,6 +126,7 @@ export function update (id, dt, world) {
 
   /* ---------- 5. Работа на месте или поиск тайла ---------------------- */
   const idx = posY[id] * MAP_W + posX[id];
+  if (jobType[id] === 3) return;
   if (workTimer[id] > 0) {
     workTimer[id] -= dt;
     if (workTimer[id] <= 0) {

--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
     <span id="houses"></span>
     <span id="fps"></span>
     <button id="details-btn">Stats</button>
+    <div id="speed-controls">
+      <button data-s="0">0x</button>
+      <button data-s="1">1x</button>
+      <button data-s="2">2x</button>
+      <button data-s="3">3x</button>
+      <button data-s="4">4x</button>
+      <button data-s="5">5x</button>
+    </div>
   </div>
 
   <div id="villagers" class="panel" style="display:none"></div>

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const hud = {
 };
 const panel = document.getElementById('villagers');
 const detailsBtn = document.getElementById('details-btn');
+const speedControls = document.getElementById('speed-controls');
 
 let mapW = 0, mapH = 0;
 let tiles, agents = { x: [], y: [], age: [], hunger: [], home: [], skillFood: [], skillWood: [] }, houses = [];
@@ -43,6 +44,12 @@ window.addEventListener('keydown', e => {
   if (e.key === 'v') togglePanel();
 });
 detailsBtn.addEventListener('click', togglePanel);
+if (speedControls) {
+  speedControls.addEventListener('click', e => {
+    const v = e.target.getAttribute('data-s');
+    if (v !== null) worker.postMessage({type:'speed', value: Number(v)});
+  });
+}
 
 // панорамирование
 let panX = 0, panY = 0, panning = false, startX = 0, startY = 0;

--- a/style.css
+++ b/style.css
@@ -47,6 +47,18 @@
   font-size: 12px;
 }
 
+#speed-controls {
+  display: flex;
+  gap: 2px;
+  margin-top: 2px;
+  pointer-events: auto;
+}
+
+#speed-controls button {
+  pointer-events: auto;
+  font-size: 12px;
+}
+
 .panel {
   position: fixed;
   top: 6px;


### PR DESCRIPTION
## Summary
- add per-agent house building logic with build timers
- restrict work and reproduction by villager age
- speed up hunger loss and reduce for kids
- allow pausing and speeding the simulation
- expose speed buttons in UI

## Testing
- `node -c sim.worker.js`
- `node -c ai/builder.js`
- `node -c ai/farmer.js`


------
https://chatgpt.com/codex/tasks/task_e_6859e352b02c8332b96cdae20b6589db