### PR TITLE
Improve housing and price dynamics

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -18,8 +18,13 @@ export function update(id, dt, world) {
 
   if (age[id] < 16) return;
   const h = homeId[id];
-  if (h < 0 || h >= houseCount) return;
-  if (houseOccupants[h] <= 2) return;
+  let needBuild = false;
+  if (houseCount === 0 || h < 0 || h >= houseCount) {
+    needBuild = true;
+  } else if (houseOccupants[h] > 2) {
+    needBuild = true;
+  }
+  if (!needBuild) return;
 
   if (jobType[id] === 3) {
     if (posX[id] === buildX[id] && posY[id] === buildY[id]) {
@@ -47,6 +52,17 @@ export function update(id, dt, world) {
   if (stockWood < WOOD_COST) return;
 
   let bx = -1, by = -1, best = Infinity;
+  let refX = posX[id], refY = posY[id];
+  if (h >= 0 && h < houseCount) {
+    refX = houseX[h];
+    refY = houseY[h];
+  } else if (houseCount > 0) {
+    let dist = Infinity;
+    for (let i = 0; i < houseCount; i++) {
+      const d = (houseX[i] - posX[id]) ** 2 + (houseY[i] - posY[id]) ** 2;
+      if (d < dist) { dist = d; refX = houseX[i]; refY = houseY[i]; }
+    }
+  }
   for (let i = 0; i < tiles.length; i++) {
     if (tiles[i] !== TILE_GRASS || reserved[i] !== -1) continue;
     const x = i % MAP_W, y = (i / MAP_W) | 0;
@@ -55,7 +71,7 @@ export function update(id, dt, world) {
       if (houseX[h2] === x && houseY[h2] === y) { occupied = true; break; }
     }
     if (occupied) continue;
-    const d = (x - houseX[h]) ** 2 + (y - houseY[h]) ** 2;
+    const d = (x - refX) ** 2 + (y - refY) ** 2;
     if (d < best) { best = d; bx = x; by = y; }
   }
   if (bx < 0) return;

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -105,7 +105,8 @@ export function update (id, dt, world) {
   /* ---------- 2. Еда --------------------------------------------------- */
   if (hunger[id] < 30 && stockFood > 0) {
     world.stockFood--;                // съели единицу еды
-    hunger[id] = 100;
+    const restore = 15 + Math.random() * 15;
+    hunger[id] = Math.min(100, hunger[id] + restore);
     return;
   }
 

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -123,8 +123,8 @@ function updatePrices(dt) {
   const baseWood = 0.5;
   const targetFood = baseFood * agentCount / Math.max(_stockFood, 1);
   const targetWood = baseWood * agentCount / Math.max(_stockWood, 1);
-  _priceFood += (_priceFood ? (targetFood - _priceFood) : targetFood) * 0.1 * dt;
-  _priceWood += (_priceWood ? (targetWood - _priceWood) : targetWood) * 0.1 * dt;
+  _priceFood += (_priceFood ? (targetFood - _priceFood) : targetFood) * dt;
+  _priceWood += (_priceWood ? (targetWood - _priceWood) : targetWood) * dt;
   if (Math.random() < dt * 0.1) {
     _priceFood *= 1 + (Math.random() - 0.5) * 0.02;
     _priceWood *= 1 + (Math.random() - 0.5) * 0.02;


### PR DESCRIPTION
## Summary
- villagers now consider building a first house when none exist or when homeless
- select building spot near the nearest existing house if no home
- eating restores a random 15-30 hunger instead of full
- make prices react more quickly to stock changes

## Testing
- `node --check ai/builder.js`
- `node --check ai/farmer.js`
- `node --check sim.worker.js`

------
https://chatgpt.com/codex/tasks/task_e_685a4380ffe883328fd4f3b35eac6d87