### PR TITLE
Fix builder housing conditions and reservation cleanup

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -24,7 +24,7 @@ export function update(id, dt, world) {
   let needBuild = false;
   if (houseCount === 0 || h < 0 || h >= houseCount) {
     needBuild = true;
-  } else if (houseOccupants[h] > 2) {
+  } else if (houseOccupants[h] >= houseCapacity[h]) {
     needBuild = true;
   }
   const needStore = Math.floor(houseCount / 10) > storeCount;

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -41,15 +41,15 @@ export function update (id, dt, world) {
   }
   if (homeId[id] === -1) {
     for (let h = 0; h < houseCount; h++) {
-      if (houseOccupants[h] < 2) {
+      if (houseOccupants[h] < houseCapacity[h]) {
         homeId[id] = h;
         houseOccupants[h]++;
         break;
       }
     }
-  } else if (houseOccupants[homeId[id]] > 2) {
+  } else if (houseOccupants[homeId[id]] > houseCapacity[homeId[id]]) {
     for (let h = 0; h < houseCount; h++) {
-      if (houseOccupants[h] < 2) {
+      if (houseOccupants[h] < houseCapacity[h]) {
         houseOccupants[homeId[id]]--;
         homeId[id] = h;
         houseOccupants[h]++;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -183,6 +183,11 @@ function tick() {
     }
   }
 
+  // очищаем устаревшие бронировки плиток после смерти жителей
+  for (let i = 0; i < reserved.length; i++) {
+    if (reserved[i] >= agentCount) reserved[i] = -1;
+  }
+
   // 2. Реген поля и леса (шанс зависит от скорости)
   for (let i = 0; i < MAP_SIZE; i++) {
     if (tiles[i] === TILE_GRASS && Math.random() < 0.0005 * dt) {


### PR DESCRIPTION
## Summary
- cap house building and assignment using actual capacity
- release reserved tiles when an agent dies

## Testing
- `node -c ai/builder.js`
- `node -c ai/farmer.js`
- `node -c sim.worker.js`


------
https://chatgpt.com/codex/tasks/task_e_685a4e958a7c8332a071ff78222404e8