### PR TITLE
Improve economy and buildings

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -83,6 +83,32 @@ export function update(id, dt, world) {
         world.houseCapacity[hc] = 5;
         world.houseOccupants[hc] = 0;
         world.houseCount = hc + 1;
+
+        if (world.storeCount < world.storeX.length) {
+          const dirs = [
+            [1, 0], [-1, 0], [0, 1], [0, -1]
+          ];
+          for (const [dx, dy] of dirs) {
+            const sx = buildX[id] + dx;
+            const sy = buildY[id] + dy;
+            if (sx < 0 || sx >= MAP_W || sy < 0 || sy >= MAP_H) continue;
+            if (tiles[sy * MAP_W + sx] !== TILE_GRASS) continue;
+            let occupied = false;
+            for (let h2 = 0; h2 < world.houseCount && !occupied; h2++) {
+              if (world.houseX[h2] === sx && world.houseY[h2] === sy) occupied = true;
+            }
+            for (let s2 = 0; s2 < world.storeCount && !occupied; s2++) {
+              if (world.storeX[s2] === sx && world.storeY[s2] === sy) occupied = true;
+            }
+            if (occupied) continue;
+            const sc = world.storeCount;
+            world.storeX[sc] = sx;
+            world.storeY[sc] = sy;
+            world.storeSize[sc] = 4;
+            world.storeCount = sc + 1;
+            break;
+          }
+        }
       } else {
         const sc = world.storeCount;
         world.storeX[sc] = buildX[id];

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -86,7 +86,7 @@ export function update (id, dt, world) {
   }
 
   /* ---------- Нести ресурсы на склад ------------------------------- */
-  if (carryFood[id] > 0 || carryWood[id] > 0) {
+  if (carryFood[id] >= 10 || carryWood[id] >= 10 || jobType[id] === 4 || jobType[id] === 5) {
     if (storeCount > 0) {
       let best = Infinity, tx = posX[id], ty = posY[id], si = -1;
       for (let i = 0; i < storeCount; i++) {
@@ -184,18 +184,19 @@ export function update (id, dt, world) {
     workTimer[id] -= dt;
     if (workTimer[id] <= 0) {
       tiles[idx] = TILE_GRASS;
-        if (jobType[id] === 1) {
-        carryFood[id] = Math.min(5, carryFood[id] + 1);
+      if (jobType[id] === 1) {
+        carryFood[id] = Math.min(10, carryFood[id] + 1);
         const cap = Math.min(20, Math.floor(age[id] / 3.5));
         if (skillFood[id] < cap && Math.random() < 0.25) skillFood[id]++;
+        jobType[id] = carryFood[id] >= 10 ? 4 : 0;
       }
-        if (jobType[id] === 2) {
-        carryWood[id] = Math.min(5, carryWood[id] + 1);
+      if (jobType[id] === 2) {
+        carryWood[id] = Math.min(10, carryWood[id] + 1);
         const cap = Math.min(20, Math.floor(age[id] / 3.5));
         if (skillWood[id] < cap && Math.random() < 0.25) skillWood[id]++;
+        jobType[id] = carryWood[id] >= 10 ? 5 : 0;
       }
       if (reserved[idx] === id) reserved[idx] = -1;
-      jobType[id] = jobType[id] === 1 ? 4 : 5;
     }
     return;
   }

--- a/data/resources.json
+++ b/data/resources.json
@@ -5,6 +5,6 @@
     "basePrice": 1
   },
   "wood": {
-    "basePrice": 0.5
+    "basePrice": 1
   }
 }

--- a/main.js
+++ b/main.js
@@ -43,12 +43,9 @@ function drawStore(x, y, ts) {
   ctx.fillStyle = '#777';
   ctx.fillRect(x * ts + ts * 0.1, y * ts + ts * 0.1, ts * 0.8, ts * 0.8);
   ctx.strokeStyle = '#fff';
-  ctx.beginPath();
-  ctx.moveTo(x * ts + ts * 0.3, y * ts + ts * 0.5);
-  ctx.lineTo(x * ts + ts * 0.7, y * ts + ts * 0.5);
-  ctx.moveTo(x * ts + ts * 0.5, y * ts + ts * 0.3);
-  ctx.lineTo(x * ts + ts * 0.5, y * ts + ts * 0.7);
-  ctx.stroke();
+  ctx.setLineDash([ts * 0.2, ts * 0.2]);
+  ctx.strokeRect(x * ts + ts * 0.1, y * ts + ts * 0.1, ts * 0.8, ts * 0.8);
+  ctx.setLineDash([]);
 }
 
 function drawVillager(x, y, ts, old) {
@@ -107,24 +104,42 @@ function showAgent(e) {
   for (let i = 0; i < agents.x.length; i++) {
     if (agents.x[i] === x && agents.y[i] === y) { idx = i; break; }
   }
-  if (idx === -1) {
-    agentInfo.style.display = 'none';
+  if (idx !== -1) {
+    agentInfo.style.display = 'block';
+    agentInfo.style.left = e.clientX + 10 + 'px';
+    agentInfo.style.top  = e.clientY + 10 + 'px';
+    const jobMap = {
+      0: 'idle',
+      1: 'harvest',
+      2: 'chop',
+      3: 'build',
+      4: 'store food',
+      5: 'store wood',
+      6: 'build store'
+    };
+    const job = jobMap[agents.job[idx]] || 'unknown';
+    agentInfo.innerHTML = `age:${agents.age[idx].toFixed(0)}<br/>hunger:${agents.hunger[idx].toFixed(0)}<br/>task:${job}`;
     return;
   }
-  agentInfo.style.display = 'block';
-  agentInfo.style.left = e.clientX + 10 + 'px';
-  agentInfo.style.top  = e.clientY + 10 + 'px';
-  const jobMap = {
-    0: 'idle',
-    1: 'harvest',
-    2: 'chop',
-    3: 'build',
-    4: 'store food',
-    5: 'store wood',
-    6: 'build store'
-  };
-  const job = jobMap[agents.job[idx]] || 'unknown';
-  agentInfo.innerHTML = `age:${agents.age[idx].toFixed(0)}<br/>hunger:${agents.hunger[idx].toFixed(0)}<br/>task:${job}`;
+  for (let i = 0; i < houses.length; i++) {
+    if (houses[i].x === x && houses[i].y === y) {
+      agentInfo.style.display = 'block';
+      agentInfo.style.left = e.clientX + 10 + 'px';
+      agentInfo.style.top  = e.clientY + 10 + 'px';
+      agentInfo.innerHTML = `house ${i}<br/>cap:${houses[i].capacity} occ:${houses[i].occupants}`;
+      return;
+    }
+  }
+  for (let i = 0; i < stores.length; i++) {
+    if (stores[i].x === x && stores[i].y === y) {
+      agentInfo.style.display = 'block';
+      agentInfo.style.left = e.clientX + 10 + 'px';
+      agentInfo.style.top  = e.clientY + 10 + 'px';
+      agentInfo.innerHTML = `store ${i}<br/>food:${stores[i].food} wood:${stores[i].wood}`;
+      return;
+    }
+  }
+  agentInfo.style.display = 'none';
 }
 canvas.addEventListener('pointerdown', e => {
   panning = true;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -83,7 +83,7 @@ const carryWood  = new Uint8Array(MAX_AGENTS);
 let _stockFood = 50;
 let _stockWood = 100;
 let _priceFood = 1;
-let _priceWood = 0.5;
+let _priceWood = 1;
 
 // Мир для AI
 const world = {
@@ -166,18 +166,17 @@ initFarmer(world);
 initBuilder(world);
 
 function updatePrices(dt) {
-  const baseFood = 1;
-  const baseWood = 0.5;
-  const targetFood = baseFood * agentCount / Math.max(_stockFood, 1);
-  const targetWood = baseWood * agentCount / Math.max(_stockWood, 1);
-  _priceFood += (_priceFood ? (targetFood - _priceFood) : targetFood) * dt;
-  _priceWood += (_priceWood ? (targetWood - _priceWood) : targetWood) * dt;
-  if (Math.random() < dt * 0.1) {
-    _priceFood *= 1 + (Math.random() - 0.5) * 0.02;
-    _priceWood *= 1 + (Math.random() - 0.5) * 0.02;
+  const base = 1;
+  const targetFood = base * agentCount / Math.max(_stockFood, 1);
+  const targetWood = base * agentCount / Math.max(_stockWood, 1);
+  _priceFood += (targetFood - _priceFood) * dt * 3;
+  _priceWood += (targetWood - _priceWood) * dt * 3;
+  if (Math.random() < dt * 0.2) {
+    _priceFood *= 1 + (Math.random() - 0.5) * 0.2;
+    _priceWood *= 1 + (Math.random() - 0.5) * 0.2;
   }
-  _priceFood = Math.min(Math.max(_priceFood, 0.5), 8);
-  _priceWood = Math.min(Math.max(_priceWood, 0.3), 6);
+  _priceFood = Math.min(Math.max(_priceFood, 0.0001), 1000);
+  _priceWood = Math.min(Math.max(_priceWood, 0.0001), 1000);
 }
 
 // Начальная передача карты
@@ -276,7 +275,9 @@ function tick() {
     stores: Array.from({ length: storeCount }, (_, i) => ({
       x: storeX[i],
       y: storeY[i],
-      size: storeSize[i]
+      size: storeSize[i],
+      food: storeFood[i],
+      wood: storeWood[i]
     })),
     stats: { pop: agentCount, food: _stockFood, wood: _stockWood, priceFood: _priceFood, priceWood: _priceWood, houses: houseCount, stores: storeCount },
     fps: Math.round(1 / dt)


### PR DESCRIPTION
## Summary
- vary resource prices more and unify base price
- create warehouse near each new house
- limit settlers to 10 items before storing
- draw warehouses with dashed outline
- show info for houses and warehouses on hover

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685ab7de67dc833282f4914e91fa3a48