### PR TITLE
Fix builders stopping mid-construction

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -50,11 +50,7 @@ export function update(id, dt, world) {
     }
     needBuild = !free;
   }
-  const needStore = Math.floor(houseCount / 10) > storeCount;
-  if (!needBuild && !needStore) return;
-
-  if (jobType[id] !== 0 && jobType[id] !== 3 && jobType[id] !== 6) return;
-
+  // продолжить уже начатое строительство независимо от потребностей
   if (jobType[id] === 3 || jobType[id] === 6) {
     if (posX[id] !== buildX[id] || posY[id] !== buildY[id]) {
       stepToward(id, buildX[id], buildY[id], world);
@@ -121,6 +117,11 @@ export function update(id, dt, world) {
     }
     return;
   }
+
+  const needStore = Math.floor(houseCount / 10) > storeCount;
+  if (!needBuild && !needStore) return;
+
+  if (jobType[id] !== 0) return;
 
   const buildStore = needStore && stockWood >= STORE_WOOD;
   if (!buildStore && stockWood < WOOD_COST) return;


### PR DESCRIPTION
## Summary
- ensure builders finish constructing houses or stores even if demand changes

## Testing
- `node --check ai/builder.js`
- `for f in main.js sim.worker.js ai/*.js events/*.js ecs/*.js; do node --check "$f"; done`
- `node -e "globalThis.postMessage=()=>{}; globalThis.self=globalThis; import('./sim.worker.js'); setTimeout(()=>process.exit(),1000);"`

------
https://chatgpt.com/codex/tasks/task_e_685c21e4e9a48332a7bebbf9a2f94a27