### PR TITLE
Fix builder wood retrieval

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -189,5 +189,9 @@ function takeWood(amount, world) {
       amount -= w;
     }
   }
+  if (amount > 0 && world.stockWood >= amount) {
+    world.stockWood -= amount;
+    amount = 0;
+  }
   return amount === 0;
 }


### PR DESCRIPTION
## Summary
- allow builders to fallback to global wood stock when stores are empty

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685c274542dc8332b033b0058a76fc86