### PR TITLE
Implement new village mechanics

### DIFF
--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -10,6 +10,8 @@ const TILE_FIELD  = 3;
 const TIME_HARVEST = 3;  // базовое время сбора пищи
 const TIME_CHOP    = 5;  // базовое время рубки дерева
 
+import { pathStep } from './path.js';
+
 export function init () {
   /* ничего инициализировать не нужно */
 }
@@ -229,15 +231,10 @@ export function update (id, dt, world) {
 
 /* -------------------------------------------------------------------- */
 /*  Простая функция движения на один шаг в сторону цели                 */
-function stepToward (id, tx, ty, world) {
-  const { posX, posY, reserved, MAP_W, MAP_H } = world;
-  const dx = tx - posX[id];
-  const dy = ty - posY[id];
-  let nx = posX[id], ny = posY[id];
-  if (Math.abs(dx) > Math.abs(dy)) nx += Math.sign(dx);
-  else                              ny += Math.sign(dy);
-  nx = Math.max(0, Math.min(MAP_W - 1, nx));
-  ny = Math.max(0, Math.min(MAP_H - 1, ny));
-  posX[id] = nx;
-  posY[id] = ny;
+
+function stepToward(id, tx, ty, world) {
+  const { posX, posY } = world;
+  const { x, y } = pathStep(posX[id], posY[id], tx, ty, world);
+  posX[id] = x;
+  posY[id] = y;
 }

--- a/ai/path.js
+++ b/ai/path.js
@@ -1,0 +1,31 @@
+export function pathStep(sx, sy, tx, ty, world) {
+  const { MAP_W, MAP_H, tiles } = world;
+  const visited = new Set();
+  const queue = [];
+  queue.push({x:sx,y:sy,prev:null});
+  visited.add(sx+","+sy);
+  const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+  function passable(x,y){
+    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return false;
+    return tiles[y*MAP_W+x]!==1;
+  }
+  let end=null;
+  let idx=0;
+  while(idx<queue.length){
+    const cur=queue[idx++];
+    if(cur.x===tx&&cur.y===ty){end=cur;break;}
+    for(const[dx,dy]of dirs){
+      const nx=cur.x+dx, ny=cur.y+dy;
+      const key=nx+","+ny;
+      if(!passable(nx,ny)||visited.has(key)) continue;
+      visited.add(key);
+      queue.push({x:nx,y:ny,prev:idx-1});
+    }
+  }
+  if(!end) return {x:sx,y:sy};
+  let node=end;
+  while(node.prev!==null&&!(queue[node.prev].x===sx&&queue[node.prev].y===sy)){
+    node=queue[node.prev];
+  }
+  return {x:node.x,y:node.y};
+}

--- a/main.js
+++ b/main.js
@@ -48,6 +48,13 @@ function drawStore(x, y, ts) {
   ctx.setLineDash([]);
 }
 
+function drawCorpse(x, y, ts) {
+  ctx.fillStyle = '#aa2222';
+  ctx.beginPath();
+  ctx.arc(x * ts + ts / 2, y * ts + ts / 2, ts * 0.2, 0, Math.PI * 2);
+  ctx.fill();
+}
+
 function drawVillager(x, y, ts, old) {
   ctx.fillStyle = old ? '#ccc' : '#eee';
   ctx.beginPath();
@@ -55,7 +62,7 @@ function drawVillager(x, y, ts, old) {
   ctx.fill();
 }
 let tiles, agents = { x: [], y: [], age: [], hunger: [], home: [], skillFood: [], skillWood: [], job: [] },
-    houses = [], stores = [];
+    houses = [], stores = [], corpses = [];
 let stats = { pop: 0, food: 0, wood: 0, priceFood: 0, priceWood: 0, houses: 0, stores: 0 }, fps = 0;
 let lastTime = performance.now();
 // убираем смену дня и ночи
@@ -170,6 +177,7 @@ worker.onmessage = e => {
     agents   = msg.agents;
     houses   = msg.houses;
     stores   = msg.stores || [];
+    corpses  = msg.corpses || [];
     stats    = msg.stats;
     fps      = msg.fps;
   }
@@ -213,6 +221,9 @@ function render() {
     stores.forEach(s => {
       drawStore(s.x, s.y, ts);
     });
+
+    // трупы
+    corpses.forEach(c => drawCorpse(c.x, c.y, ts));
 
     // поселенцы
     for (let i = 0; i < agents.x.length; i++) {


### PR DESCRIPTION
## Summary
- add BFS pathfinding helper
- integrate new pathStep into farmer and builder
- give builders ability to create new farm fields
- track parent relationships and corpses in the simulation
- share skills when villagers meet
- render corpses on the map

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_685c2f9e63d88332a99e2a2375828232