### PR TITLE
Improve food management and allow kids to use stores

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -23,13 +23,13 @@ export function update(id, dt, world) {
     agentCount, withdraw
   } = world;
 
-  if (age[id] < 16) return;
+  // дети также могут пользоваться складом и строить
   const h = homeId[id];
 
   if (hunger[id] < 30 && stockFood > 0) {
     let best = Infinity, tx = posX[id], ty = posY[id], si = -1;
     for (let i = 0; i < storeCount; i++) {
-      if (storeFood[i] > 0) {
+      if (storeFood[i] >= 5) {
         const x = storeX[i], y = storeY[i];
         const d = (x - posX[id]) ** 2 + (y - posY[id]) ** 2;
         if (d < best) { best = d; tx = x; ty = y; si = i; }
@@ -37,8 +37,8 @@ export function update(id, dt, world) {
     }
     if (si >= 0) {
       if (posX[id] === tx && posY[id] === ty) {
-        if (withdraw(si, 1, 0)) {
-          const restore = 15 + Math.random() * 15;
+        if (withdraw(si, 5, 0)) {
+          const restore = (15 + Math.random() * 15) * 5;
           hunger[id] = Math.min(100, hunger[id] + restore);
         }
       } else {
@@ -46,9 +46,12 @@ export function update(id, dt, world) {
       }
       return;
     } else {
-      world.stockFood--;
-      const restore = 15 + Math.random() * 15;
-      hunger[id] = Math.min(100, hunger[id] + restore);
+      const taken = Math.min(5, world.stockFood);
+      world.stockFood -= taken;
+      if (taken > 0) {
+        const restore = (15 + Math.random() * 15) * taken;
+        hunger[id] = Math.min(100, hunger[id] + restore);
+      }
       return;
     }
   }


### PR DESCRIPTION
## Summary
- let builders ignore the age restriction so kids can visit stores
- keep 5 items when depositing resources
- withdraw 5 food at once when hungry
- adjust hunger logic for both builders and farmers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c3dafb9ac8332a1bbee7b147869fa