### PR TITLE
Refactor tile constants into shared module

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -1,6 +1,6 @@
 // ai/builder.js — поселенцы строят дома при нехватке жилья
 
-const TILE_GRASS = 0;
+import { TILE_GRASS, TILE_FIELD } from '../data/constants.js';
 
 const TIME_BUILD = 8;            // время постройки
 const WOOD_COST  = 15;
@@ -155,7 +155,7 @@ export function update(id, dt, world) {
         world.storeSize[sc] = 4;
         world.storeCount = sc + 1;
       } else {
-        tiles[buildY[id] * MAP_W + buildX[id]] = 3;
+        tiles[buildY[id] * MAP_W + buildX[id]] = TILE_FIELD;
       }
       reserved[buildY[id] * MAP_W + buildX[id]] = -1;
       jobType[id] = 0;
@@ -165,7 +165,7 @@ export function update(id, dt, world) {
   }
 
   let fields = 0;
-  for (let i = 0; i < tiles.length; i++) if (tiles[i] === 3) fields++;
+  for (let i = 0; i < tiles.length; i++) if (tiles[i] === TILE_FIELD) fields++;
   const needStore = Math.floor(houseCount / 10) > storeCount;
   const needFarm  = fields < houseCount * 2;
   if (!needBuild && !needStore && !needFarm) return;

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -2,10 +2,7 @@
 
 /* ------------------------------------------------------------------ */
 /*  Константы тайлов: должны точно совпадать с тем, что в worker.     */
-const TILE_GRASS  = 0;
-const TILE_WATER  = 1;
-const TILE_FOREST = 2;
-const TILE_FIELD  = 3;
+import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD } from '../data/constants.js';
 /* ------------------------------------------------------------------ */
 const TIME_HARVEST = 3;  // базовое время сбора пищи
 const TIME_CHOP    = 5;  // базовое время рубки дерева

--- a/data/constants.js
+++ b/data/constants.js
@@ -1,0 +1,4 @@
+export const TILE_GRASS = 0;
+export const TILE_WATER = 1;
+export const TILE_FOREST = 2;
+export const TILE_FIELD = 3;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 // main.js — UI и рендер, оптимизировано для мобильных
 
+import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD } from './data/constants.js';
 const worker = new Worker('sim.worker.js', { type: 'module' });
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -204,9 +205,9 @@ function render() {
       for (let x = 0; x < mapW; x++) {
         const t = tiles[y * mapW + x];
         // 0 = grass, 1 = water, 2 = forest, 3 = field
-        if (t === 1) ctx.fillStyle = TILE_COLORS.water;
-        else if (t === 2) ctx.fillStyle = TILE_COLORS.forest;
-        else if (t === 3) ctx.fillStyle = TILE_COLORS.field;
+        if (t === TILE_WATER) ctx.fillStyle = TILE_COLORS.water;
+        else if (t === TILE_FOREST) ctx.fillStyle = TILE_COLORS.forest;
+        else if (t === TILE_FIELD) ctx.fillStyle = TILE_COLORS.field;
         else ctx.fillStyle = TILE_COLORS.grass;
         ctx.fillRect(x * ts, y * ts, ts, ts);
       }

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -2,6 +2,7 @@
 
 import { init as initFarmer, update as updateFarmer } from './ai/farmer.js';
 import { init as initBuilder, update as updateBuilder } from './ai/builder.js';
+import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD } from './data/constants.js';
 
 const MAP_W    = 64;
 const MAP_H    = 64;
@@ -9,10 +10,6 @@ const MAP_SIZE = MAP_W * MAP_H;
 const AGE_SPEED = 1 / 60; // 1 year per 60 sec
 const HUNGER_RATE = 100 / 60; // 100 hunger per year
 
-const TILE_GRASS  = 0;
-const TILE_WATER  = 1;
-const TILE_FOREST = 2;
-const TILE_FIELD  = 3;
 
 // Карта
 const tiles = new Uint8Array(MAP_SIZE);


### PR DESCRIPTION
## Summary
- add `data/constants.js` defining shared tile constants
- import these constants in the farmer AI, builder AI, worker and main renderer
- use the constants when comparing tile values

## Testing
- `node --check main.js`
- `node --check ai/builder.js`
- `node --check ai/farmer.js`
- `node --check sim.worker.js`


------
https://chatgpt.com/codex/tasks/task_e_685c415f6938833294185ac4de491ac5