### PR TITLE
Account for villagers aging

### DIFF
--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -178,8 +178,10 @@ export function update (id, dt, world) {
   const woodPrice = world.priceWood;
 
   /* ---------- 4. Навык и прибыль -------------------------------------- */
-  const harvestSpeed = 1 + skillFood[id] * 0.1;
-  const chopSpeed    = 1 + skillWood[id] * 0.1;
+  // после 50 лет жители постепенно теряют силу
+  const ageMul = age[id] <= 50 ? 1 : Math.max(0.5, 1 - (age[id] - 50) * 0.02);
+  const harvestSpeed = (1 + skillFood[id] * 0.1) * ageMul;
+  const chopSpeed    = (1 + skillWood[id] * 0.1) * ageMul;
   const harvestTime  = TIME_HARVEST / harvestSpeed;
   const chopTime     = TIME_CHOP / chopSpeed;
   const profitHarvest = foodPrice / harvestTime;
@@ -199,13 +201,13 @@ export function update (id, dt, world) {
       if (jobType[id] === JOB_HARVEST) {
         carryFood[id] = Math.min(10, carryFood[id] + 1);
         const cap = Math.min(20, Math.floor(age[id] / 3.5));
-        if (skillFood[id] < cap && Math.random() < 0.25) skillFood[id]++;
+        if (age[id] <= 60 && skillFood[id] < cap && Math.random() < 0.25) skillFood[id]++;
         jobType[id] = carryFood[id] >= 10 ? JOB_STORE_FOOD : JOB_IDLE;
       }
       if (jobType[id] === JOB_CHOP) {
         carryWood[id] = Math.min(10, carryWood[id] + 1);
         const cap = Math.min(20, Math.floor(age[id] / 3.5));
-        if (skillWood[id] < cap && Math.random() < 0.25) skillWood[id]++;
+        if (age[id] <= 60 && skillWood[id] < cap && Math.random() < 0.25) skillWood[id]++;
         jobType[id] = carryWood[id] >= 10 ? JOB_STORE_WOOD : JOB_IDLE;
       }
       if (reserved[idx] === id) reserved[idx] = -1;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -7,7 +7,10 @@ import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD } from './data/constant
 const MAP_W    = 64;
 const MAP_H    = 64;
 const MAP_SIZE = MAP_W * MAP_H;
-const AGE_SPEED = 1 / 60; // 1 year per 60 sec
+// AGE_SPEED определяет скорость старения.
+// Значение 1/60 означает, что один игровой год длится 60 секунд реального времени.
+// После 50 лет скорость работы постепенно снижается, а после 70 лет жители умирают.
+const AGE_SPEED = 1 / 60;
 const HUNGER_RATE = 100 / 60; // 100 hunger per year
 
 
@@ -209,6 +212,7 @@ function tick() {
     hunger[i] = Math.max(0, hunger[i] - dt * hungerRate);
     thirst[i] = Math.max(0, thirst[i] - dt * 0.2);  // −0.2 ед/сек
     energy[i] = Math.min(100, energy[i] + dt * 0.5);// +0.5 ед/сек
+    // старение происходит непрерывно: 1 игровой год = 60 секунд
     age[i]   += dt * AGE_SPEED;
 
     // смерть от голода или старости


### PR DESCRIPTION
## Summary
- clarify the year duration and aging effect in `AGE_SPEED`
- slow villagers down after 50 years old
- cap skill growth for older villagers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4af9cfdc8332b6e01a153d8f30b7