### PR TITLE
Fix hunger behavior and reassign idle builders

### DIFF
--- a/ai/builder.js
+++ b/ai/builder.js
@@ -26,11 +26,27 @@ export function update(id, dt, world) {
     stockWood, stockFood, workTimer, jobType,
     buildX, buildY,
     storeX, storeY, storeSize, storeCount, storeFood,
-    agentCount, withdraw
+    agentCount, withdraw,
+    carryFood, role
   } = world;
 
   // дети также могут пользоваться складом и строить
   const h = homeId[id];
+
+  // перекусить из собственных запасов, если других источников нет
+  if (hunger[id] < 30 && carryFood[id] > 0) {
+    const take = Math.min(carryFood[id], 5);
+    carryFood[id] -= take;
+    const restore = (15 + Math.random() * 15) * take;
+    hunger[id] = Math.min(100, hunger[id] + restore);
+    return;
+  }
+
+  // при нехватке еды бездействующий строитель переключается на фермерские работы
+  if (stockFood < agentCount && jobType[id] === JOB_IDLE) {
+    role[id] = 0; // стать фермером
+    return;
+  }
 
   if (hunger[id] < 30 && stockFood > 0) {
     let best = Infinity, tx = posX[id], ty = posY[id], si = -1;

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -91,6 +91,14 @@ export function update (id, dt, world) {
     return;
   }
 
+  // съесть припасённую еду, если уровень голода низкий
+  if (hunger[id] < 30 && carryFood[id] > 0) {
+    const take = Math.min(carryFood[id], 5);
+    carryFood[id] -= take;
+    const restore = (15 + Math.random() * 15) * take;
+    hunger[id] = Math.min(100, hunger[id] + restore);
+  }
+
   /* ---------- Нести ресурсы на склад ------------------------------- */
   if (carryFood[id] >= 10 || carryWood[id] >= 10 || jobType[id] === JOB_STORE_FOOD || jobType[id] === JOB_STORE_WOOD) {
     if (storeCount > 0) {


### PR DESCRIPTION
## Summary
- allow villagers to eat food they carry with them
- convert idle builders to farmers during food shortages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4ee757d08332a7d46e076153e94b