### PR TITLE
Remove sprite assets and use shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@
       <button data-s="4">4x</button>
       <button data-s="5">5x</button>
     </div>
+    <div id="build-controls">
+      <button data-build="house">House</button>
+      <button data-build="store">Store</button>
+    </div>
   </div>
 
   <div id="villagers" class="panel" style="display:none"></div>

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -196,6 +196,29 @@ for (let i = 0; i < 20; i++) {
   );
 }
 
+function placeBuilding(type, x, y) {
+  if (x < 0 || x >= MAP_W || y < 0 || y >= MAP_H) return;
+  for (let i = 0; i < houseCount; i++) if (houseX[i] === x && houseY[i] === y) return;
+  for (let i = 0; i < storeCount; i++) if (storeX[i] === x && storeY[i] === y) return;
+  if (tiles[y * MAP_W + x] !== TILE_GRASS) return;
+  if (type === 'house' && _stockWood >= 15 && houseCount < MAX_HOUSES) {
+    houseX[houseCount] = x;
+    houseY[houseCount] = y;
+    houseCapacity[houseCount] = 5;
+    houseOccupants[houseCount] = 0;
+    houseCount++;
+    _stockWood -= 15;
+  } else if (type === 'store' && _stockWood >= 20 && storeCount < MAX_STORES) {
+    storeX[storeCount] = x;
+    storeY[storeCount] = y;
+    storeSize[storeCount] = 4;
+    storeFood[storeCount] = 0;
+    storeWood[storeCount] = 0;
+    storeCount++;
+    _stockWood -= 20;
+  }
+}
+
 // Инициализируем AI
 initFarmer(world);
 initBuilder(world);
@@ -237,6 +260,9 @@ let last = performance.now();
 let gameSpeed = 1;
 self.onmessage = e => {
   if (e.data && e.data.type === 'speed') gameSpeed = e.data.value;
+  if (e.data && e.data.type === 'place') {
+    placeBuilding(e.data.what, e.data.x, e.data.y);
+  }
 };
 function tick() {
   recordStats();

--- a/style.css
+++ b/style.css
@@ -59,6 +59,18 @@
   font-size: 12px;
 }
 
+#build-controls {
+  display: flex;
+  gap: 2px;
+  margin-top: 2px;
+  pointer-events: auto;
+}
+
+#build-controls button {
+  pointer-events: auto;
+  font-size: 12px;
+}
+
 .panel {
   position: fixed;
   top: 6px;


### PR DESCRIPTION
## Summary
- drop binary sprite images
- draw houses, stores and agents with canvas shapes
- keep zoom and manual build controls

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c521a5f4883328ccd855ce1f6ba40