### PR TITLE
Add event emissions for births, deaths and building completion

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -14,3 +14,31 @@ test('on/emit/off works for events', () => {
   emit('tick', 1);
   expect(value).toBe(1);
 });
+
+test('birth, death and building-complete payloads', () => {
+  const births = [];
+  const deaths = [];
+  const builds = [];
+  function bh(p) { births.push(p); }
+  function dh(p) { deaths.push(p); }
+  function ch(p) { builds.push(p); }
+
+  on('birth', bh);
+  on('death', dh);
+  on('building-complete', ch);
+
+  const bData = { id: 1, x: 2, y: 3 };
+  const dData = { id: 2, x: 4, y: 5 };
+  const cData = { type: 'house', x: 5, y: 6 };
+  emit('birth', bData);
+  emit('death', dData);
+  emit('building-complete', cData);
+
+  expect(births[0]).toEqual(bData);
+  expect(deaths[0]).toEqual(dData);
+  expect(builds[0]).toEqual(cData);
+
+  off('birth', bh);
+  off('death', dh);
+  off('building-complete', ch);
+});

--- a/ai/builder.js
+++ b/ai/builder.js
@@ -15,6 +15,7 @@ const TIME_STORE = 10;
 const TIME_FARM  = 5;
 
 import { pathStep } from './path.js';
+import { emit } from '../events/events.js';
 
 export function init() {}
 
@@ -149,6 +150,7 @@ export function update(id, dt, world) {
         world.houseCapacity[hc] = 5;
         world.houseOccupants[hc] = 0;
         world.houseCount = hc + 1;
+        emit('building-complete', { type: 'house', x: buildX[id], y: buildY[id] });
 
         if (world.storeCount < world.storeX.length) {
           const dirs = [
@@ -181,8 +183,10 @@ export function update(id, dt, world) {
         world.storeY[sc] = buildY[id];
         world.storeSize[sc] = 4;
         world.storeCount = sc + 1;
+        emit('building-complete', { type: 'store', x: buildX[id], y: buildY[id] });
       } else {
         tiles[buildY[id] * MAP_W + buildX[id]] = TILE_FIELD;
+        emit('building-complete', { type: 'field', x: buildX[id], y: buildY[id] });
       }
       reserved[buildY[id] * MAP_W + buildX[id]] = -1;
       jobType[id] = JOB_IDLE;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -2,6 +2,7 @@
 
 import { init as initFarmer, update as updateFarmer } from './ai/farmer.js';
 import { init as initBuilder, update as updateBuilder } from './ai/builder.js';
+import { emit } from './events/events.js';
 import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD } from './data/constants.js';
 
 const MAP_W    = 64;
@@ -281,6 +282,7 @@ function tick() {
 
     // смерть от голода или старости
     if (hunger[i] === 0 || age[i] > 70) {
+      const deadInfo = { id: i, x: posX[i], y: posY[i] };
       if (corpseCount < MAX_CORPSES) {
         corpseX[corpseCount] = posX[i];
         corpseY[corpseCount] = posY[i];
@@ -299,6 +301,7 @@ function tick() {
       buildX[i]=buildX[lastId]; buildY[i]=buildY[lastId];
       carryFood[i]=carryFood[lastId]; carryWood[i]=carryWood[lastId];
       for (let r = 0; r < reserved.length; r++) if (reserved[r] === i) reserved[r] = -1;
+      emit('death', deadInfo);
       i--;
       continue;
     }
@@ -355,6 +358,7 @@ function tick() {
         parentA[child] = p1;
         parentB[child] = p2;
         spouse[child]  = -1;
+        emit('birth', { id: child, x: houseX[h], y: houseY[h] });
         if (spouse[p1] === -1) spouse[p1] = p2;
         if (spouse[p2] === -1) spouse[p2] = p1;
         houseOccupants[h]++;


### PR DESCRIPTION
## Summary
- emit `birth` and `death` events from `sim.worker.js`
- emit `building-complete` in `ai/builder.js` when a house, store or field finishes
- extend `events.test.js` to validate event payloads

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d1e18c300833284ae56923d038d81