### PR TITLE
Implement A* pathfinding with caching

### DIFF
--- a/__tests__/path.test.js
+++ b/__tests__/path.test.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@jest/globals';
+import { pathStep } from '../ai/path.js';
+
+function createWorld(tiles, w, h) {
+  return { MAP_W: w, MAP_H: h, tiles: new Uint8Array(tiles) };
+}
+
+function bfsLength(sx, sy, tx, ty, world) {
+  const { MAP_W, MAP_H, tiles } = world;
+  const visited = new Set();
+  const queue = [{ x: sx, y: sy, d: 0 }];
+  visited.add(`${sx},${sy}`);
+  const dirs = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  function passable(x, y) {
+    if (x < 0 || x >= MAP_W || y < 0 || y >= MAP_H) return false;
+    return tiles[y * MAP_W + x] !== 1;
+  }
+  let idx = 0;
+  while (idx < queue.length) {
+    const cur = queue[idx++];
+    if (cur.x === tx && cur.y === ty) return cur.d;
+    for (const [dx, dy] of dirs) {
+      const nx = cur.x + dx;
+      const ny = cur.y + dy;
+      const key = `${nx},${ny}`;
+      if (!passable(nx, ny) || visited.has(key)) continue;
+      visited.add(key);
+      queue.push({ x: nx, y: ny, d: cur.d + 1 });
+    }
+  }
+  return Infinity;
+}
+
+function runPathStep(sx, sy, tx, ty, world) {
+  let x = sx, y = sy;
+  let steps = 0;
+  let guard = 0;
+  while ((x !== tx || y !== ty) && guard < 100) {
+    const next = pathStep(x, y, tx, ty, world);
+    if (next.x === x && next.y === y) break;
+    x = next.x; y = next.y; steps++; guard++;
+  }
+  return steps;
+}
+
+test('A* path length is not longer than BFS on open grid', () => {
+  const world = createWorld([
+    0,0,0,
+    0,0,0,
+    0,0,0,
+  ], 3, 3);
+  const bfs = bfsLength(0,0,2,2,world);
+  const astar = runPathStep(0,0,2,2,world);
+  expect(astar).toBeLessThanOrEqual(bfs);
+});
+
+test('A* path length is not longer than BFS with obstacles', () => {
+  const tiles = [
+    0,0,0,0,0,
+    0,1,1,1,0,
+    0,0,0,1,0,
+    0,1,0,0,0,
+    0,0,0,0,0,
+  ];
+  const world = createWorld(tiles,5,5);
+  const bfs = bfsLength(0,0,4,4,world);
+  const astar = runPathStep(0,0,4,4,world);
+  expect(astar).toBeLessThanOrEqual(bfs);
+});

--- a/ai/path.js
+++ b/ai/path.js
@@ -1,31 +1,102 @@
-export function pathStep(sx, sy, tx, ty, world) {
+const dirs = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+function manhattan(x1, y1, x2, y2) {
+  return Math.abs(x1 - x2) + Math.abs(y1 - y2);
+}
+
+function passable(x, y, world) {
   const { MAP_W, MAP_H, tiles } = world;
-  const visited = new Set();
-  const queue = [];
-  queue.push({x:sx,y:sy,prev:null});
-  visited.add(sx+","+sy);
-  const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
-  function passable(x,y){
-    if(x<0||x>=MAP_W||y<0||y>=MAP_H) return false;
-    return tiles[y*MAP_W+x]!==1;
+  if (x < 0 || x >= MAP_W || y < 0 || y >= MAP_H) return false;
+  return tiles[y * MAP_W + x] !== 1;
+}
+
+function reconstructPath(nodes, endIdx) {
+  const path = [];
+  let n = nodes[endIdx];
+  while (n) {
+    path.push({ x: n.x, y: n.y });
+    n = n.prev != null ? nodes[n.prev] : null;
   }
-  let end=null;
-  let idx=0;
-  while(idx<queue.length){
-    const cur=queue[idx++];
-    if(cur.x===tx&&cur.y===ty){end=cur;break;}
-    for(const[dx,dy]of dirs){
-      const nx=cur.x+dx, ny=cur.y+dy;
-      const key=nx+","+ny;
-      if(!passable(nx,ny)||visited.has(key)) continue;
-      visited.add(key);
-      queue.push({x:nx,y:ny,prev:idx-1});
+  return path.reverse();
+}
+
+function aStar(sx, sy, tx, ty, world) {
+  if (sx === tx && sy === ty) return [{ x: sx, y: sy }];
+  const nodes = [];
+  const open = [];
+  const visited = new Map();
+
+  const start = { x: sx, y: sy, g: 0, h: manhattan(sx, sy, tx, ty) };
+  start.f = start.g + start.h;
+  start.prev = null;
+  nodes.push(start);
+  open.push(0);
+  visited.set(`${sx},${sy}`, 0);
+
+  let endIdx = -1;
+  while (open.length > 0) {
+    let best = 0;
+    for (let i = 1; i < open.length; i++) {
+      if (nodes[open[i]].f < nodes[open[best]].f) best = i;
+    }
+    const curIdx = open.splice(best, 1)[0];
+    const cur = nodes[curIdx];
+
+    if (cur.x === tx && cur.y === ty) { endIdx = curIdx; break; }
+
+    for (const [dx, dy] of dirs) {
+      const nx = cur.x + dx;
+      const ny = cur.y + dy;
+      if (!passable(nx, ny, world)) continue;
+      const key = `${nx},${ny}`;
+      const g = cur.g + 1;
+      if (visited.has(key)) {
+        const idx = visited.get(key);
+        if (g < nodes[idx].g) {
+          nodes[idx].g = g;
+          nodes[idx].f = g + nodes[idx].h;
+          nodes[idx].prev = curIdx;
+          if (!open.includes(idx)) open.push(idx);
+        }
+        continue;
+      }
+      const h = manhattan(nx, ny, tx, ty);
+      const node = { x: nx, y: ny, g, h, f: g + h, prev: curIdx };
+      const idx = nodes.push(node) - 1;
+      visited.set(key, idx);
+      open.push(idx);
     }
   }
-  if(!end) return {x:sx,y:sy};
-  let node=end;
-  while(node.prev!==null&&!(queue[node.prev].x===sx&&queue[node.prev].y===sy)){
-    node=queue[node.prev];
+
+  if (endIdx === -1) return [{ x: sx, y: sy }];
+  return reconstructPath(nodes, endIdx);
+}
+
+const pathCache = new Map();
+
+export function pathStep(sx, sy, tx, ty, world) {
+  const key = `${sx},${sy}->${tx},${ty}`;
+  let entry = pathCache.get(key);
+
+  if (!entry || entry.path[entry.index].x !== sx || entry.path[entry.index].y !== sy) {
+    const path = aStar(sx, sy, tx, ty, world);
+    entry = { path, index: 0 };
   }
-  return {x:node.x,y:node.y};
+
+  if (entry.path.length < 2 || entry.index + 1 >= entry.path.length) {
+    return { x: sx, y: sy };
+  }
+
+  const next = entry.path[entry.index + 1];
+  pathCache.delete(key);
+  if (entry.index + 1 < entry.path.length - 1) {
+    pathCache.set(`${next.x},${next.y}->${tx},${ty}`, { path: entry.path, index: entry.index + 1 });
+  }
+
+  return { x: next.x, y: next.y };
 }


### PR DESCRIPTION
## Summary
- replace BFS search in `pathStep` with A* using the Manhattan heuristic
- add a simple cache so subsequent calls reuse the same path
- add tests comparing A* results with a BFS implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d236f061c8332b7e6de41240f86db