### PR TITLE
Ignore negative amounts in storage operations

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -10,6 +10,8 @@ function createStorage(size = 1) {
   let tickFoodIn = 0, tickWoodIn = 0, tickFoodOut = 0, tickWoodOut = 0;
 
   function deposit(storeIndex, food = 0, wood = 0) {
+    food = Math.max(0, food);
+    wood = Math.max(0, wood);
     if (storeIndex < 0 || storeIndex >= storeCount) return 0;
     const cap = storeSize[storeIndex] * 100;
     const used = storeFood[storeIndex] + storeWood[storeIndex];
@@ -34,6 +36,8 @@ function createStorage(size = 1) {
   }
 
   function withdraw(storeIndex, food = 0, wood = 0) {
+    food = Math.max(0, food);
+    wood = Math.max(0, wood);
     if (storeIndex < 0 || storeIndex >= storeCount) return false;
     if (food > storeFood[storeIndex] || wood > storeWood[storeIndex]) return false;
     storeFood[storeIndex] -= food;
@@ -105,6 +109,25 @@ describe('storage deposit/withdraw', () => {
     expect(ok).toBe(false);
     expect(storage.storeFood[0]).toBe(3);
     expect(storage.stockFood).toBe(0);
+  });
+
+  test('negative values are ignored', () => {
+    storage.storeFood[0] = 50;
+    storage.storeWood[0] = 20;
+
+    let deposited = storage.deposit(0, -10, -5);
+    expect(deposited).toBe(0);
+    expect(storage.storeFood[0]).toBe(50);
+    expect(storage.storeWood[0]).toBe(20);
+    expect(storage.stockFood).toBe(0);
+    expect(storage.stockWood).toBe(0);
+
+    const result = storage.withdraw(0, -15, -3);
+    expect(result).toBe(true); // withdraw of 0 should succeed
+    expect(storage.storeFood[0]).toBe(50);
+    expect(storage.storeWood[0]).toBe(20);
+    expect(storage.stockFood).toBe(0);
+    expect(storage.stockWood).toBe(0);
   });
 });
 

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -137,6 +137,8 @@ const world = {
   get priceWood() { return _priceWood; },
   set priceWood(v) { _priceWood = v; },
   deposit(storeIndex, food = 0, wood = 0) {
+    food = Math.max(0, food);
+    wood = Math.max(0, wood);
     if (storeIndex < 0 || storeIndex >= storeCount) return 0;
     const cap = storeSize[storeIndex] * 100;
     const used = storeFood[storeIndex] + storeWood[storeIndex];
@@ -160,6 +162,8 @@ const world = {
     return deposited;
   },
   withdraw(storeIndex, food = 0, wood = 0) {
+    food = Math.max(0, food);
+    wood = Math.max(0, wood);
     if (storeIndex < 0 || storeIndex >= storeCount) return false;
     if (food > storeFood[storeIndex] || wood > storeWood[storeIndex]) return false;
     storeFood[storeIndex] -= food;


### PR DESCRIPTION
## Summary
- guard against negative amounts in `world.deposit` and `world.withdraw`
- update test helper storage functions with the same guards
- test that negative values do not change store or stock

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d24fd5c488332b6ac1954bfd71a29