### PR TITLE
Improve path cache cleanup

### DIFF
--- a/ai/path.js
+++ b/ai/path.js
@@ -79,6 +79,10 @@ function aStar(sx, sy, tx, ty, world) {
 
 const pathCache = new Map();
 
+export function clearPathCache(limit = 1000) {
+  if (pathCache.size > limit) pathCache.clear();
+}
+
 export function pathStep(sx, sy, tx, ty, world) {
   const key = `${sx},${sy}->${tx},${ty}`;
   let entry = pathCache.get(key);
@@ -89,6 +93,7 @@ export function pathStep(sx, sy, tx, ty, world) {
   }
 
   if (entry.path.length < 2 || entry.index + 1 >= entry.path.length) {
+    pathCache.delete(key);
     return { x: sx, y: sy };
   }
 

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -2,6 +2,7 @@
 
 import { init as initFarmer, update as updateFarmer } from './ai/farmer.js';
 import { init as initBuilder, update as updateBuilder } from './ai/builder.js';
+import { clearPathCache } from './ai/path.js';
 import { emit } from './events/events.js';
 import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD,
          TILE_FIELD_GROW, TILE_FOREST_GROW } from './data/constants.js';
@@ -290,6 +291,7 @@ self.onmessage = e => {
 };
 function tick() {
   recordStats();
+  clearPathCache();
   const now = performance.now();
   const dt  = (now - last) / 1000 * gameSpeed;
   last = now;


### PR DESCRIPTION
## Summary
- delete path cache entries when a path is finished
- periodically clear cached paths with a size check
- clear path cache once per tick in the worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d2e881ff48332b23f013bcc7856e4