### PR TITLE
Add button selection highlight

### DIFF
--- a/main.js
+++ b/main.js
@@ -93,22 +93,38 @@ resize();
 
 // переключение панели с жителями
 function togglePanel() {
-  panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+  const open = panel.style.display === 'none';
+  panel.style.display = open ? 'block' : 'none';
+  detailsBtn.classList.toggle('active', open);
 }
 window.addEventListener('keydown', e => {
   if (e.key === 'v') togglePanel();
 });
 detailsBtn.addEventListener('click', togglePanel);
 if (speedControls) {
+  const defaultBtn = speedControls.querySelector('[data-s="1"]');
+  if (defaultBtn) defaultBtn.classList.add('active');
   speedControls.addEventListener('click', e => {
-    const v = e.target.getAttribute('data-s');
-    if (v !== null) worker.postMessage({type:'speed', value: Number(v)});
+    const btn = e.target.closest('button');
+    if (!btn) return;
+    const v = btn.getAttribute('data-s');
+    if (v !== null) {
+      worker.postMessage({type:'speed', value: Number(v)});
+      speedControls.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    }
   });
 }
 if (buildControls) {
   buildControls.addEventListener('click', e => {
-    const mode = e.target.getAttribute('data-build');
-    if (mode) buildMode = mode;
+    const btn = e.target.closest('button');
+    if (!btn) return;
+    const mode = btn.getAttribute('data-build');
+    if (mode) {
+      buildMode = mode;
+      buildControls.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    }
   });
 }
 
@@ -180,6 +196,9 @@ canvas.addEventListener('pointerdown', e => {
     const y = Math.floor((e.clientY - panY) / ts);
     worker.postMessage({type:'place', what: buildMode, x, y});
     buildMode = null;
+    if (buildControls) {
+      buildControls.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+    }
     return;
   }
   panning = true;

--- a/style.css
+++ b/style.css
@@ -71,6 +71,12 @@
   font-size: 12px;
 }
 
+/* highlighted state for selected buttons */
+.active {
+  background: #444;
+  color: #fff;
+}
+
 .panel {
   position: fixed;
   top: 6px;


### PR DESCRIPTION
## Summary
- add `.active` class for selected controls
- keep active state when clicking speed, build or stats controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d308f8a7483328620bac8408e53ef