### PR TITLE
Improve role switching with global food check

### DIFF
--- a/__tests__/builder-role.test.js
+++ b/__tests__/builder-role.test.js
@@ -44,15 +44,15 @@ function createWorld() {
   };
 }
 
-test('builder toggles back when food stock is sufficient', () => {
+test('builder toggles role when food supply changes', () => {
   const world = createWorld();
 
   // low food causes switch to farmer
   updateBuilder(0, 0, world);
   expect(world.role[0]).toBe(0);
 
-  // replenish food and run update again
-  world.stockFood = 2;
+  // replenish food comfortably above threshold and run update again
+  world.stockFood = 4;
   updateBuilder(0, 0, world);
   expect(world.role[0]).toBe(1);
 });

--- a/ai/builder.js
+++ b/ai/builder.js
@@ -16,6 +16,7 @@ const TIME_FARM  = 5;
 
 import { pathStep } from './path.js';
 import { emit } from '../events/events.js';
+import { isFoodLow } from './farmer.js';
 
 export function init() {}
 
@@ -63,13 +64,13 @@ export function update(id, dt, world) {
   }
 
   // при нехватке еды бездействующий строитель переключается на фермерские работы
-  if (stockFood < agentCount && jobType[id] === JOB_IDLE) {
+  if (isFoodLow(world) && jobType[id] === JOB_IDLE) {
     role[id] = 0; // стать фермером
     return;
   }
 
   // запасы восстановились — возвращаемся к строительству
-  if (stockFood >= agentCount * 2 && role[id] === 0) {
+  if (stockFood >= agentCount * 4 && role[id] === 0) {
     role[id] = 1;
   }
 

--- a/ai/farmer.js
+++ b/ai/farmer.js
@@ -21,6 +21,10 @@ const FOREST_GROW_TIME = 60;
 
 import { pathStep } from './path.js';
 
+export function isFoodLow(world) {
+  return world.stockFood < world.agentCount * 2;
+}
+
 export function init () {
   /* ничего инициализировать не нужно */
 }
@@ -40,6 +44,8 @@ export function update (id, dt, world) {
     storeX, storeY, storeSize, storeCount,
     reserved
   } = world;
+
+  const lowFood = isFoodLow(world);
 
   // лёгкая усталость от времени
   energy[id] = Math.max(0, energy[id] - dt * 0.2);
@@ -235,7 +241,7 @@ export function update (id, dt, world) {
   const profitHarvest = foodPrice / harvestTime;
   const profitChop    = woodPrice / chopTime;
 
-  let harvestMode = profitHarvest >= profitChop;
+  let harvestMode = lowFood || profitHarvest >= profitChop;
   if (hunger[id] < 30 && world.stockFood === 0) harvestMode = true;
   const targetType  = harvestMode ? TILE_FIELD : TILE_FOREST;
   const growType = harvestMode ? TILE_FIELD_GROW : TILE_FOREST_GROW;


### PR DESCRIPTION
## Summary
- add `isFoodLow` helper to farmer AI
- use helper in farmer AI to prefer harvesting when food is scarce
- switch builder role based on global food shortage and relax back when stocks are high
- update builder role test for new logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d4d2c3f5c83328d4465ae0be5b096