### PR TITLE
Add market building and trader logic

### DIFF
--- a/__tests__/trader.test.js
+++ b/__tests__/trader.test.js
@@ -50,3 +50,21 @@ test('trader transfers resources between stores', () => {
   expect(world.storeFood[1]).toBeGreaterThan(0);
   expect(world.jobType[0]).toBe(JOB_IDLE);
 });
+
+test('trader sells resources at market', () => {
+  const world = createWorld();
+  world.marketCount = 1;
+  world.marketX = new Uint8Array([1]);
+  world.marketY = new Uint8Array([0]);
+
+  world.posX[0] = 0;
+  world.posY[0] = 0;
+  updateTrader(0, 0, world); // pick up from store 0
+  expect(world.carryFood[0]).toBeGreaterThan(0);
+
+  // move to market to sell
+  world.posX[0] = 1;
+  updateTrader(0, 0, world);
+  expect(world.carryFood[0]).toBe(0);
+  expect(world.jobType[0]).toBe(JOB_IDLE);
+});

--- a/ai/trader.js
+++ b/ai/trader.js
@@ -8,9 +8,10 @@ export function init() {}
 export function update(id, dt, world) {
   const {
     storeCount, storeFood, storeWood, storeX, storeY,
+    marketCount = 0, marketX = [], marketY = [],
     posX, posY, carryFood, carryWood, jobType
   } = world;
-  if (storeCount < 2) return;
+  if (storeCount < 1) return;
 
   // choose richest and poorest stores by total resources
   let richest = 0, poorest = 0;
@@ -39,17 +40,42 @@ export function update(id, dt, world) {
     }
     jobType[id] = JOB_TRADER;
   } else {
-    // move to poorest store and deposit resources
-    const tx = storeX[poorest], ty = storeY[poorest];
-    if (posX[id] !== tx || posY[id] !== ty) {
-      stepToward(id, tx, ty, world);
-      jobType[id] = JOB_TRADER;
-      return;
+    if (marketCount > 0) {
+      // move to nearest market and sell resources
+      let best = Infinity, mx = marketX[0], my = marketY[0];
+      for (let i = 0; i < marketCount; i++) {
+        const d = (marketX[i] - posX[id]) ** 2 + (marketY[i] - posY[id]) ** 2;
+        if (d < best) { best = d; mx = marketX[i]; my = marketY[i]; }
+      }
+      if (posX[id] !== mx || posY[id] !== my) {
+        stepToward(id, mx, my, world);
+        jobType[id] = JOB_TRADER;
+        return;
+      }
+      // sell: simply drop carried resources
+      carryFood[id] = 0;
+      carryWood[id] = 0;
+      jobType[id] = JOB_IDLE;
+    } else {
+      // move to poorest store and deposit resources
+      const tx = storeX[poorest], ty = storeY[poorest];
+      if (posX[id] !== tx || posY[id] !== ty) {
+        stepToward(id, tx, ty, world);
+        jobType[id] = JOB_TRADER;
+        return;
+      }
+      world.deposit(poorest, carryFood[id], carryWood[id]);
+      carryFood[id] = 0;
+      carryWood[id] = 0;
+      jobType[id] = JOB_IDLE;
     }
-    world.deposit(poorest, carryFood[id], carryWood[id]);
-    carryFood[id] = 0;
-    carryWood[id] = 0;
-    jobType[id] = JOB_IDLE;
   }
+}
+
+function stepToward(id, tx, ty, world) {
+  const { posX, posY } = world;
+  const { x, y } = pathStep(posX[id], posY[id], tx, ty, world);
+  posX[id] = x;
+  posY[id] = y;
 }
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       <button data-build="house">House</button>
       <button data-build="store">Store</button>
       <button data-build="field">Field</button>
+      <button data-build="market">Market</button>
     </div>
     <button id="trader-btn">Trader</button>
     <button id="save-btn">Save</button>

--- a/main.js
+++ b/main.js
@@ -72,6 +72,18 @@ function drawStore(x, y, ts) {
   ctx.setLineDash([]);
 }
 
+function drawMarket(x, y, ts) {
+  ctx.fillStyle = '#cdbb3b';
+  ctx.fillRect(x * ts + ts * 0.05, y * ts + ts * 0.2, ts * 0.9, ts * 0.6);
+  ctx.fillStyle = '#946b2d';
+  ctx.beginPath();
+  ctx.moveTo(x * ts + ts * 0.05, y * ts + ts * 0.2);
+  ctx.lineTo(x * ts + ts * 0.5, y * ts + ts * 0.05);
+  ctx.lineTo(x * ts + ts * 0.95, y * ts + ts * 0.2);
+  ctx.closePath();
+  ctx.fill();
+}
+
 function drawCorpse(x, y, ts) {
   ctx.fillStyle = '#aa2222';
   ctx.beginPath();
@@ -87,8 +99,8 @@ function drawVillager(x, y, ts, old) {
   ctx.fill();
 }
 let tiles, agents = { x: [], y: [], age: [], hunger: [], home: [], skillFood: [], skillWood: [], job: [] },
-    houses = [], stores = [], corpses = [];
-let stats = { pop: 0, food: 0, wood: 0, priceFood: 0, priceWood: 0, houses: 0, stores: 0 }, fps = 0;
+    houses = [], stores = [], markets = [], corpses = [];
+let stats = { pop: 0, food: 0, wood: 0, priceFood: 0, priceWood: 0, houses: 0, stores: 0, markets: 0 }, fps = 0;
 let lastTime = performance.now();
 // убираем смену дня и ночи
 
@@ -222,6 +234,15 @@ function showAgent(e) {
       return;
     }
   }
+  for (let i = 0; i < markets.length; i++) {
+    if (markets[i].x === x && markets[i].y === y) {
+      agentInfo.style.display = 'block';
+      agentInfo.style.left = e.clientX + 10 + 'px';
+      agentInfo.style.top  = e.clientY + 10 + 'px';
+      agentInfo.textContent = `market ${i}`;
+      return;
+    }
+  }
   agentInfo.style.display = 'none';
 }
 canvas.addEventListener('pointerdown', e => {
@@ -277,6 +298,7 @@ worker.onmessage = e => {
     agents   = msg.agents;
     houses   = msg.houses;
     stores   = msg.stores || [];
+    markets  = msg.markets || [];
     corpses  = msg.corpses || [];
     stats    = msg.stats;
     fps      = msg.fps;
@@ -339,6 +361,11 @@ function render() {
       drawStore(s.x, s.y, ts);
     });
 
+    // рынки
+    markets.forEach(m => {
+      drawMarket(m.x, m.y, ts);
+    });
+
     // трупы
     corpses.forEach(c => drawCorpse(c.x, c.y, ts));
 
@@ -356,11 +383,11 @@ function render() {
   hud.wood.textContent   = `Wood: ${stats.wood}`;
   hud.priceFood.textContent = `F$ ${stats.priceFood.toFixed(2)}`;
   hud.priceWood.textContent = `W$ ${stats.priceWood.toFixed(2)}`;
-  hud.houses.textContent = `Houses: ${stats.houses} S:${stats.stores}`;
+  hud.houses.textContent = `Houses: ${stats.houses} S:${stats.stores} M:${stats.markets}`;
   hud.fps.textContent    = `FPS:  ${fps}`;
 
   if (panel.style.display !== 'none') {
-    let text = `World pop:${stats.pop} food:${stats.food} wood:${stats.wood} houses:${stats.houses} stores:${stats.stores}\n` +
+    let text = `World pop:${stats.pop} food:${stats.food} wood:${stats.wood} houses:${stats.houses} stores:${stats.stores} markets:${stats.markets}\n` +
                `priceF:${stats.priceFood.toFixed(2)} priceW:${stats.priceWood.toFixed(2)}\n\n`;
     for (let i = 0; i < agents.x.length; i++) {
       text += `#${i} age:${agents.age[i].toFixed(1)} hunger:${agents.hunger[i].toFixed(0)} home:${agents.home[i]} food:${agents.skillFood[i]} wood:${agents.skillWood[i]}\n`;

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -101,6 +101,12 @@ const storeFood  = new Uint16Array(MAX_STORES);
 const storeWood  = new Uint16Array(MAX_STORES);
 let storeCount = 0;
 
+// Рынки
+const MAX_MARKETS = 5;
+const marketX = new Uint8Array(MAX_MARKETS);
+const marketY = new Uint8Array(MAX_MARKETS);
+let marketCount = 0;
+
 const MAX_CORPSES = 50;
 const corpseX = new Uint8Array(MAX_CORPSES);
 const corpseY = new Uint8Array(MAX_CORPSES);
@@ -126,6 +132,7 @@ const world = {
   set time(v) { worldTime = (v / 24) * DAY_LENGTH; },
   houseX, houseY, houseCapacity, houseOccupants,
   storeX, storeY, storeSize, storeFood, storeWood,
+  marketX, marketY,
   corpseX, corpseY, corpseTimer,
   get agentCount() { return agentCount; },
   set agentCount(v) { agentCount = v; },
@@ -133,6 +140,8 @@ const world = {
   set houseCount(v) { houseCount = v; },
   get storeCount() { return storeCount; },
   set storeCount(v) { storeCount = v; },
+  get marketCount() { return marketCount; },
+  set marketCount(v) { marketCount = v; },
   get stockFood() { return _stockFood; },
   set stockFood(v) {
     if (v > _stockFood) tickFoodIn += v - _stockFood;
@@ -221,6 +230,7 @@ function placeBuilding(type, x, y) {
   if (x < 0 || x >= MAP_W || y < 0 || y >= MAP_H) return;
   for (let i = 0; i < houseCount; i++) if (houseX[i] === x && houseY[i] === y) return;
   for (let i = 0; i < storeCount; i++) if (storeX[i] === x && storeY[i] === y) return;
+  for (let i = 0; i < marketCount; i++) if (marketX[i] === x && marketY[i] === y) return;
   if (tiles[y * MAP_W + x] !== TILE_GRASS) return;
   if (type === 'house' && _stockWood >= 15 && houseCount < MAX_HOUSES) {
     houseX[houseCount] = x;
@@ -239,6 +249,11 @@ function placeBuilding(type, x, y) {
     _stockWood -= 20;
   } else if (type === 'field') {
     tiles[y * MAP_W + x] = TILE_FIELD;
+  } else if (type === 'market' && _stockWood >= 30 && marketCount < MAX_MARKETS) {
+    marketX[marketCount] = x;
+    marketY[marketCount] = y;
+    marketCount++;
+    _stockWood -= 30;
   }
 }
 
@@ -494,11 +509,15 @@ function tick() {
       food: storeFood[i],
       wood: storeWood[i]
     })),
+    markets: Array.from({ length: marketCount }, (_, i) => ({
+      x: marketX[i],
+      y: marketY[i]
+    })),
     corpses: Array.from({ length: corpseCount }, (_, i) => ({
       x: corpseX[i],
       y: corpseY[i]
     })),
-    stats: { pop: agentCount, food: _stockFood, wood: _stockWood, priceFood: _priceFood, priceWood: _priceWood, houses: houseCount, stores: storeCount },
+    stats: { pop: agentCount, food: _stockFood, wood: _stockWood, priceFood: _priceFood, priceWood: _priceWood, houses: houseCount, stores: storeCount, markets: marketCount },
     fps: Math.round(1 / dt)
   });
 

--- a/utils/stateStorage.js
+++ b/utils/stateStorage.js
@@ -37,6 +37,9 @@ export function serializeWorld(world) {
     storeSize: Array.from(world.storeSize.slice(0, world.storeCount)),
     storeFood: Array.from(world.storeFood.slice(0, world.storeCount)),
     storeWood: Array.from(world.storeWood.slice(0, world.storeCount)),
+    marketCount: world.marketCount,
+    marketX: Array.from(world.marketX.slice(0, world.marketCount)),
+    marketY: Array.from(world.marketY.slice(0, world.marketCount)),
     corpseCount: world.corpseCount,
     corpseX: Array.from(world.corpseX.slice(0, world.corpseCount)),
     corpseY: Array.from(world.corpseY.slice(0, world.corpseCount)),
@@ -95,6 +98,10 @@ export function deserializeWorld(world, data) {
   copyArray(world.storeSize, data.storeSize || [], world.storeCount);
   copyArray(world.storeFood, data.storeFood || [], world.storeCount);
   copyArray(world.storeWood, data.storeWood || [], world.storeCount);
+
+  world.marketCount = data.marketCount ?? 0;
+  copyArray(world.marketX, data.marketX || [], world.marketCount);
+  copyArray(world.marketY, data.marketY || [], world.marketCount);
 
   world.corpseCount = data.corpseCount ?? 0;
   copyArray(world.corpseX, data.corpseX || [], world.corpseCount);


### PR DESCRIPTION
## Summary
- expand storage arrays to include markets and send to UI
- allow placing `market` in sim worker
- extend serialization for markets
- draw market sprite and handle markets in UI
- add market button in HTML
- update trader AI to sell resources at markets
- test trader sells resources at market

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e50b9edb08332a7eeca8ea9d3f332