### PR TITLE
Improve starting behavior and in‑game save loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
 
   <div id="villagers" class="panel" style="display:none"></div>
   <div id="agent-info" class="panel" style="display:none"></div>
+  <div id="load-modal" class="panel" style="display:none"></div>
 
   <!-- Главный UI-скрипт (модуль) -->
   <script type="module" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 import { TILE_GRASS, TILE_WATER, TILE_FOREST, TILE_FIELD,
          TILE_FIELD_GROW, TILE_FOREST_GROW } from './data/constants.js';
 import { JOBS } from './data/jobTypes.js';
-import { saveGame, loadGame, hasSavedGame } from './utils/stateStorage.js';
+import { saveGame, loadGame, hasSavedGame, getSaveInfo } from './utils/stateStorage.js';
 
 class SoundManager {
   constructor() {
@@ -48,12 +48,42 @@ const notifications = document.createElement('div');
 notifications.id = 'notifications';
 document.body.appendChild(notifications);
 
+const loadModal = document.getElementById('load-modal');
+
+
 function notify(text) {
   const div = document.createElement('div');
   div.className = 'notification';
   div.textContent = text;
   notifications.appendChild(div);
   setTimeout(() => div.remove(), 4000);
+}
+
+function showLoadPrompt() {
+  const info = getSaveInfo();
+  if (!info) return;
+  const date = info.savedAt ? new Date(info.savedAt) : null;
+  const text = date ? `Load game from ${date.toLocaleString()}?` : 'Load saved game?';
+  loadModal.innerHTML = '';
+  const msg = document.createElement('div');
+  msg.textContent = text;
+  const btns = document.createElement('div');
+  const yes = document.createElement('button');
+  yes.textContent = 'Load';
+  yes.addEventListener('click', () => {
+    loadGame(worker);
+    loadModal.style.display = 'none';
+  });
+  const no = document.createElement('button');
+  no.textContent = 'Cancel';
+  no.addEventListener('click', () => {
+    loadModal.style.display = 'none';
+  });
+  btns.appendChild(yes);
+  btns.appendChild(no);
+  loadModal.appendChild(msg);
+  loadModal.appendChild(btns);
+  loadModal.style.display = 'block';
 }
 
 let mapW = 0, mapH = 0;
@@ -192,7 +222,7 @@ if (saveBtn) {
 }
 if (loadBtn) {
   loadBtn.addEventListener('click', () => {
-    loadGame(worker);
+    showLoadPrompt();
   });
 }
 
@@ -425,6 +455,6 @@ function render() {
 requestAnimationFrame(render);
 
 // load saved game on start if present
-if (hasSavedGame() && confirm('Load saved game?')) {
-  loadGame(worker);
+if (hasSavedGame()) {
+  showLoadPrompt();
 }

--- a/sim.worker.js
+++ b/sim.worker.js
@@ -32,7 +32,8 @@ let statsIdx = 0;
 let tickFoodIn = 0, tickFoodOut = 0, tickWoodIn = 0, tickWoodOut = 0;
 
 const DAY_LENGTH = 120; // seconds per full day
-let worldTime = 0; // current time in seconds
+// Начинаем утро, чтобы жители сразу были активны
+let worldTime = DAY_LENGTH * 6 / 24; // current time in seconds
 
 
 // Карта

--- a/style.css
+++ b/style.css
@@ -119,3 +119,18 @@
   padding: 4px 6px;
   border-radius: 4px;
 }
+
+#load-modal {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  pointer-events: auto;
+  max-width: 200px;
+}
+
+#load-modal button {
+  margin: 4px;
+  font-size: 12px;
+  pointer-events: auto;
+}

--- a/utils/stateStorage.js
+++ b/utils/stateStorage.js
@@ -129,17 +129,31 @@ function waitForSave(worker) {
 
 export async function saveGame(worker) {
   const state = await waitForSave(worker);
-  localStorage.setItem('village-save', JSON.stringify(state));
+  const data = { savedAt: Date.now(), state };
+  localStorage.setItem('village-save', JSON.stringify(data));
+}
+
+export function getSaveInfo() {
+  const text = localStorage.getItem('village-save');
+  if (!text) return null;
+  try {
+    const data = JSON.parse(text);
+    if (data && typeof data === 'object' && 'state' in data) {
+      return { savedAt: data.savedAt, state: data.state };
+    }
+    return { savedAt: null, state: data };
+  } catch {
+    return null;
+  }
 }
 
 export function loadGame(worker) {
-  const text = localStorage.getItem('village-save');
-  if (!text) return false;
-  const state = JSON.parse(text);
-  worker.postMessage({ type: 'load', state });
+  const info = getSaveInfo();
+  if (!info) return false;
+  worker.postMessage({ type: 'load', state: info.state });
   return true;
 }
 
 export function hasSavedGame() {
-  return localStorage.getItem('village-save') !== null;
+  return getSaveInfo() !== null;
 }


### PR DESCRIPTION
## Summary
- start simulation at 6 AM so villagers move right away
- show a modal to load saved games instead of a confirm dialog
- store save timestamp in local storage
- allow loading from button or on startup via the modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e7024a7e08332be22ad61dc9c07ee